### PR TITLE
Margin fix

### DIFF
--- a/assets/templates/accounts/associations_base.html
+++ b/assets/templates/accounts/associations_base.html
@@ -1,31 +1,23 @@
 {% extends 'base.html' %}
 
 {% block content %}
-        <div class="row">
-            <h2 class="col-12 pl-0">{{ association }}</h2>
-        </div>
-        <div class="row">
-            <ul class="col-12 nav nav-tabs">
-                <li class="nav-item">
-                    <a class="nav-link{% block tab_overview %}{% endblock %}"
-                       href="{% url 'association_overview' association_name=association.slug %}">Overview
-                        {% if notify_overview %}<span class="badge badge-pill badge-warning">!</span>{% endif %}
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link{% block tab_credits %}{% endblock %}"
-                       href="{% url 'association_credits' association_name=association.slug %}">Credits</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link{% block tab_members %}{% endblock %}"
-                       href="{% url 'association_members' association_name=association.slug %}">Members</a>
-                </li>
-            </ul>
-        </div>
+    <h2>{{ association }}</h2>
+    <ul class="nav nav-tabs">
+        <li class="nav-item">
+            <a class="nav-link{% block tab_overview %}{% endblock %}"
+               href="{% url 'association_overview' association_name=association.slug %}">Overview
+                {% if notify_overview %}<span class="badge badge-pill badge-warning">!</span>{% endif %}
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link{% block tab_credits %}{% endblock %}"
+               href="{% url 'association_credits' association_name=association.slug %}">Credits</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link{% block tab_members %}{% endblock %}"
+               href="{% url 'association_members' association_name=association.slug %}">Members</a>
+        </li>
+    </ul>
 
-        <div class="row">
-            <div class="col-12 pt-3">
-                {% block details %}{% endblock details %}
-            </div>
-        </div>
+    <div class="mt-3">{% block details %}{% endblock details %}</div>
 {% endblock %}

--- a/assets/templates/accounts/user_history_base.html
+++ b/assets/templates/accounts/user_history_base.html
@@ -2,15 +2,13 @@
 
 {% block content %}
 
-    <h2 class="row">{{ association }}</h2>
+    <h2>Dining history</h2>
 
-    <ul class="row nav nav-tabs">
+    <ul class="nav nav-tabs mb-3">
         <li class="nav-item">
-
             <a class="nav-link{% block tab_joined %}{% endblock %}"
                href="{% url 'history_lists' %}">Joined lists
             </a>
-
         </li>
         <li class="nav-item">
             <a class="nav-link{% block tab_claimed %}{% endblock %}"
@@ -18,9 +16,5 @@
         </li>
     </ul>
 
-    <div class="row">
-        <div class="col-12 p-4">
-            {% block details %}{% endblock details %}
-        </div>
-    </div>
+    {% block details %}{% endblock details %}
 {% endblock %}


### PR DESCRIPTION
I came across a margin bug on this page where there is not side margin next to the tabs and heading.

![](https://i.imgur.com/pDopyEG.png)

That was due to not having content placed inside of a `col`, instead merged with it :smirk: 

```html
<div class="row">
    <h2 class="col-12 pl-0">{{ association }}</h2>
</div>
```

In that case, the padding on the col that undoes the margin on the row is not applied which you can see using the dev console:

![](https://i.imgur.com/DLZi0LE.png)

I've obviously fixed it here by removing the grid layout but if you want to keep it you can change it yourself to be like this :yum:

```html
<div class="row">
    <div class="col-12"><h2>{{ association }}</h2></div>
</div>
```

This is the end result:

![](https://i.imgur.com/4qgfwXy.png)