### PR TITLE
First draft of the new approach for notifications

### DIFF
--- a/General/notifications.py
+++ b/General/notifications.py
@@ -1,0 +1,23 @@
+from General.notifications_base import TemplateMail, AbstractNotification
+
+
+class TestNotification(AbstractNotification):
+    """ A Notification class for test notifications, currently only implements mails.
+
+    """
+    mail_construction_class = TemplateMail
+
+    def __init__(self, recipients):
+        self.recipients = recipients
+
+    def get_event_data(self):
+        event_data = super(TestNotification, self).get_event_data()
+        event_data['subject'] = "This is a test message title"
+        event_data['template_name'] = 'general/testmail'
+        return event_data
+
+    def get_recipients(self):
+        return self.recipients
+
+    def filter_for_mailing(self, recipients):
+        return recipients

--- a/General/notifications_base.py
+++ b/General/notifications_base.py
@@ -1,0 +1,264 @@
+from abc import abstractmethod
+from django.conf import settings
+from django.core.mail import get_connection, EmailMessage, EmailMultiAlternatives
+from django.template.loader import get_template, TemplateDoesNotExist
+
+
+class AbstractNotification(object):
+    """ Controls who need to be informed in a certain event
+
+    Given a certain event (e.g. user is removed from dining list) determines who need to be informed
+    and in what way. Then delegates the information to the relevant message constructor classes
+
+    Attributes:
+        mail_construction_class: the class that handles the mail construction and sending
+
+    """
+    mail_construction_class = None
+
+    def notify(self):
+        """ Notify all involved in the event of the invent """
+        recipients = self.get_recipients()
+
+        # Ensure that the recipients are of a queryset
+        if recipients is settings.AUTH_USER_MODEL:
+            settings.AUTH_USER_MODEL.objects.filter(pk=recipients.pk)
+
+        if recipients is None:
+            return
+
+        mailed_recipients = self.filter_for_mailing(recipients)
+        self.inform_through_mail(mailed_recipients)
+
+    @abstractmethod
+    def get_recipients(self):
+        """ Fetches the recipients that need to be informed.
+
+        Retrieves rows pertaining to the given keys from the Table instance
+        represented by big_table.  Silly things may happen if
+        other_silly_variable is not None.
+
+        Returns:
+            Any of the following three options:
+            A Queryset of users (possibly empty)
+            A single user
+            None
+
+        Raises:
+            IOError: An error occurred accessing the bigtable.Table object.
+        """
+        return NotImplementedError()
+
+    def get_event_data(self):
+        """ Constructs the message data given to each message type
+
+        Possible basic key-pairs are:
+        active_user: The user who initiated the effect
+        related_obj: The related object related with the event
+        subject: The subject of the notiffcation (if supported)
+        """
+        return {}
+
+    @abstractmethod
+    def filter_for_mailing(self, recipients):
+        """ Filters a given queryset on the users who want to receive the notification as a
+
+        This method is abstract instead of returning the recipients to prevent casual mail implementation resulting
+        in unwanted e-mail complaints.
+
+        Args:
+            recipients: A queryset of Users.
+
+        Returns:
+            A queryset of users who want to receive the notification as mail
+        """
+        raise NotImplementedError()
+
+    def inform_through_mail(self, recipients):
+        """ Informs the users through mail
+
+        Creates an object of Mail defined in the mail_construction_class
+
+        :param recipients:
+        :return:
+        """
+        event_data = self.get_event_data()
+
+        self.mail_construction_class(**event_data).send(recipients)
+
+
+class AbstractMessage(object):
+    """ Abstract shell for the means to send a notification
+
+    This class, and it's children is responsible for constructing and sending the notifications through
+    their respective means. It is sort of the View class of notifications.
+
+    Methods:
+        construct: constructs the message
+        send: sends the message
+    """
+
+    def __init__(self, **event_data):
+        """ Initialises the message
+
+        Args:
+            event_data: A dictionary of event data to get information from
+        """
+        self.construct(**event_data)
+
+    @abstractmethod
+    def construct(self, **event_data):
+        """ Construct the message
+
+        Args:
+            event_data: A dictionary of event data to get information from
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def send(self, recipients):
+        """ Sends the constructed message to the defined recipients
+
+        Args:
+            recipients: The recipients who the message needs to be send to
+        """
+
+
+class Mail(AbstractMessage):
+    """ Constructs and sends mails
+
+    Acts in a similar way as View, except instead constructs mail layouts
+
+    """
+    message_body = ""
+
+    def construct(self, message="", **event_data):
+        self.message_body = message
+        if 'subject' in event_data:
+            self.subject = event_data.pop('subject')
+        else:
+            try:
+                self.subject
+            except AttributeError:
+                raise KeyError("No subject was present, did you forget to include it in the event data?")
+
+    def get_as_django_email_message(self, subject, recipient, connection):
+        """ Creates a django message object with the required information
+
+        Args:
+            subject: The subject of the mail
+            recipient: The recipient of the mail
+            connection: the used connection
+
+        Returns: An EmailMessage instance
+
+        """
+
+        # Personalise the message with a custom adress call
+        preamble = "Dear {user}\n"
+        preamble = preamble.format(user=recipient.first_name)
+        message = preamble + self.message_body
+
+        to = [recipient]
+
+        return EmailMessage(subject=subject,
+                            body=message,
+                            to=to,
+                            connection=connection)
+
+    def send(self, recipients):
+
+        # Open a connection to send the mail to all recipients in a single run
+        connection = get_connection()
+        connection.open()
+
+        if callable(self.subject):
+            subject = self.subject()
+        else:
+            subject = self.subject
+
+        for recipient in recipients:
+            self.get_as_django_email_message(subject, recipient, connection) \
+                .send(fail_silently=True)
+        connection.close()
+
+
+class TemplateMail(Mail):
+    txt_template = None
+    html_template = None
+    target_user_format = 'target_user'
+
+    @staticmethod
+    def _get_mail_template(full_template_name):
+        """ Gets the mail template of the given full name with the correct template loader
+
+        Returns: a Template object
+
+        """
+        try:
+            return get_template(full_template_name, using='EmailTemplates')
+        except TemplateDoesNotExist:
+            return None
+
+    def construct(self, template_name=None, **event_data):
+        super(TemplateMail, self).construct(**event_data)
+
+        if template_name is None:
+            try:
+                template_name = self.template_name
+            except AttributeError:
+                raise KeyError("No template_name was defined in the class or construct parameters")
+
+
+        # Get the templates
+        txt_template = self._get_mail_template(template_name+".txt")
+        if txt_template is None:
+            raise KeyError("{t_name} does not exist as a template".format(t_name=template_name))
+        html_template = self._get_mail_template(template_name+".html")
+
+        self.event_data = event_data
+
+        # Render the templates
+        context_data = self.get_context_data()
+        self.txt_template = txt_template.render(context_data)
+        if html_template is not None:
+            self.html_template = html_template.render(context_data)
+
+    def get_context_data(self):
+        """ Get the context data to render the template with.
+
+        Automatically copies remaining attributes from event_data
+
+        Returns: a dictionary of context data for the template
+
+        """
+        if self.event_data is None:
+            return {}
+        else:
+            self.event_data
+
+    def get_as_django_email_message(self, subject, recipient, connection):
+        # Set up the Email template with the txt_template
+
+        to = [recipient]
+
+        body_personalised = self.txt_template.format(**{self.target_user_format: recipient.first_name})
+
+        mail_obj = EmailMultiAlternatives(subject=subject, body=body_personalised, to=to, connection=connection)
+
+        # Set up the html content in the mail
+        if self.html_template is not None:
+            html_personalised = self.html_template.format(**{self.target_user_format: recipient.first_name})
+            mail_obj.attach_alternative(html_personalised, "text/html")
+
+        # Send the mail
+        return mail_obj
+
+
+
+
+
+
+
+
+

--- a/General/notifications_base.py
+++ b/General/notifications_base.py
@@ -184,6 +184,17 @@ class Mail(AbstractMessage):
 
 
 class TemplateMail(Mail):
+    """ Constructs and sends Mails through a given template (txt and html)
+
+    Inherits:
+        Mail
+
+    Attributes:
+        txt_template: the rendered txt template
+        html: the rendered html template
+        target_user_format: how the name of the recipient is called in the template
+
+    """
     txt_template = None
     html_template = None
     target_user_format = 'target_user'

--- a/UserDetails/admin.py
+++ b/UserDetails/admin.py
@@ -74,10 +74,14 @@ class CustomUserAdmin(admin.ModelAdmin):
     fields = ('username', ('first_name', 'last_name'), 'date_joined', 'email')
 
     def send_test_mail(modeladmin, request, queryset):
-        send_templated_mass_mail("Scala Dining: Testmail",
-                                 template_name="general/testmail",
-                                 recipients=queryset,
-                                 fail_silently=False)
+        from General.notifications import TestNotification
+
+        TestNotification(queryset).notify()
+
+        # send_templated_mass_mail("Scala Dining: Testmail",
+        #                          template_name="general/testmail",
+        #                          recipients=queryset,
+        #                          fail_silently=False)
 
     actions = [send_test_mail]
 

--- a/assets/mails/general/testmail.html
+++ b/assets/mails/general/testmail.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <p>
-        Hey {{ user.first_name }}
+        Hey {target_user}
     </p>
     <p>
         This is a testmail from the mail sending system of the Scala Dining App

--- a/assets/mails/general/testmail.txt
+++ b/assets/mails/general/testmail.txt
@@ -1,1 +1,3 @@
+Hey {target_user}
+
 This is a testmail


### PR DESCRIPTION
Example on how I think the new messaging system should be implemented.

I think it's best to remove the message cues and template context creation from the views. So I propose notifcations.py where we define notification classes for all notifcations.

The reason of the more advanced notification class is because in my opinion there are two questions that need to be asked when processing an event:
1) Who generally need to be informed of this event
2) How do these users want to be informed (mail, (...), not)
The latter could be adjusted through user settings which are currently not implemented, but quite easily to filter on in filter_for_mailing()


If necessary we can overwrite classes such as TemplateMail with custom template behaviour.