### PR TITLE
Implemented mailing for payment reminders

### DIFF
--- a/Dining/urls.py
+++ b/Dining/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
             path('entry/add/', views.EntryAddView.as_view(), name='entry_add'),
             path('change/', views.SlotInfoChangeView.as_view(), name='slot_change'),
             path('delete/', views.SlotDeleteView.as_view(), name='slot_delete'),
+            path('inform_payment/', views.SlotPaymentView.as_view(), name='slot_inform_payment'),
         ])),
     ])),
     path('entries/<int:pk>/delete/', views.EntryDeleteView.as_view(), name='entry_delete'),

--- a/Dining/views.py
+++ b/Dining/views.py
@@ -647,13 +647,15 @@ class SlotPaymentView(SlotOwnerMixin, View):
         unpaid_user_entries = DiningEntryUser.objects.filter(dining_list=self.dining_list, has_paid=False)
         unpaid_guest_entries = DiningEntryExternal.objects.filter(dining_list=self.dining_list, has_paid=False)
 
+        is_reminder = datetime.now().date() > self.dining_list.date
+
         is_informed = False
 
-        if unpaid_user_entries.count() > 9:
+        if unpaid_user_entries.count() > 0:
             # Set up the mail
-            subject = "Dininglist unpaid: {date}".format(date=self.dining_list.date)
+            subject = "Diningapp: Payment request: {date}".format(date=self.dining_list.date)
             template = "dining/dining_list_payment_reminder"
-            context = {'dining_list': self.dining_list, 'reminder': request.user}
+            context = {'dining_list': self.dining_list, 'reminder': request.user, 'is_reminder': is_reminder}
 
             users = User.objects.filter(diningentry__in=unpaid_user_entries)
 
@@ -663,11 +665,11 @@ class SlotPaymentView(SlotOwnerMixin, View):
                                      recipients=users)
             is_informed = True
 
-        if unpaid_guest_entries.count() > 9:
+        if unpaid_guest_entries.count() > 0:
             # Set up the mail
-            subject = "Dininglist unpaid guest: {date}".format(date=self.dining_list.date)
+            subject = "Diningapp: Payment request guest: {date}".format(date=self.dining_list.date)
             template = "dining/dining_list_payment_reminder_external"
-            context = {'dining_list': self.dining_list, 'reminder': request.user}
+            context = {'dining_list': self.dining_list, 'reminder': request.user, 'is_reminder': is_reminder}
 
             users = User.objects.filter(diningentry__in=unpaid_guest_entries).distinct()
 

--- a/Dining/views.py
+++ b/Dining/views.py
@@ -478,8 +478,42 @@ class SlotInfoView(LoginRequiredMixin, SlotMixin, TemplateView):
             return self.render_to_response(context)
 
 
+class IsOwnerMixin(object):
+    """
+    Ensures the page can only be visited by dining list owners
+
+    Attributes:
+        redirect_name: The url name to redirect to upon rejection
+        base_redirect: the actual url to redirect to, can be called when succesfully processing the page
+    """
+    redirect_name = "slot_details"
+
+    @property
+    def base_redirect(self):
+        return self.reverse(self.redirect_name)
+
+    def dispatch(self, request, *args, **kwargs):
+        """
+        Construct date before get/post is called.
+        """
+        if not self.dining_list.is_owner(request.user):
+            if hasattr(self, "base_redirect"):
+                messages.error(request, "You are not the owner of this list and can't do this action")
+                return HttpResponseRedirect(self.base_redirect)
+            else:
+                return HttpResponseForbidden()
+        return super().dispatch(request, *args, **kwargs)
+
+
+class SlotOwnerMixin(LoginRequiredMixin, SlotMixin, IsOwnerMixin):
+    """
+    Combined mixin for slot pages that should only be accessable for dining list owners
+    """
+    pass
+
+
 # Could possibly use the Django built-in FormView or ModelFormView in combination with FormSet
-class SlotInfoChangeView(LoginRequiredMixin, SlotMixin, TemplateView):
+class SlotInfoChangeView(SlotOwnerMixin, TemplateView):
     template_name = "dining_lists/dining_slot_info_alter.html"
 
     def get_context_data(self, **kwargs):
@@ -523,7 +557,7 @@ class SlotInfoChangeView(LoginRequiredMixin, SlotMixin, TemplateView):
             # Ensure that current user remains owner of the dining list
             self.dining_list.owners.add(request.user)
 
-            return HttpResponseRedirect(self.reverse('slot_details'))
+            return HttpResponseRedirect(self.base_redirect)
 
         context.update({
             'info_form': info_form,
@@ -547,7 +581,7 @@ class SlotAllergyView(LoginRequiredMixin, SlotMixin, TemplateView):
         return context
 
 
-class SlotDeleteView(LoginRequiredMixin, SlotMixin, DeleteView):
+class SlotDeleteView(SlotOwnerMixin, DeleteView):
     """
     Page for slot deletion. Page is only available for slot owners.
     """
@@ -599,3 +633,73 @@ class SlotDeleteView(LoginRequiredMixin, SlotMixin, DeleteView):
             messages.add_message(request, messages.ERROR, error)
 
         return HttpResponseRedirect(self.reverse("slot_delete"))
+
+
+class SlotPaymentView(SlotOwnerMixin, View):
+    """
+    A view class that allows dining list owners to send payment reminders
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(SlotPaymentView, self).__init__(*args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        unpaid_user_entries = DiningEntryUser.objects.filter(dining_list=self.dining_list, has_paid=False)
+        unpaid_guest_entries = DiningEntryExternal.objects.filter(dining_list=self.dining_list, has_paid=False)
+
+        is_informed = False
+
+        if unpaid_user_entries.count() > 9:
+            # Set up the mail
+            subject = "Dininglist unpaid: {date}".format(date=self.dining_list.date)
+            template = "dining/dining_list_payment_reminder"
+            context = {'dining_list': self.dining_list, 'reminder': request.user}
+
+            users = User.objects.filter(diningentry__in=unpaid_user_entries)
+
+            send_templated_mass_mail(template_name=template,
+                                     subject=subject,
+                                     context_data=context,
+                                     recipients=users)
+            is_informed = True
+
+        if unpaid_guest_entries.count() > 9:
+            # Set up the mail
+            subject = "Dininglist unpaid guest: {date}".format(date=self.dining_list.date)
+            template = "dining/dining_list_payment_reminder_external"
+            context = {'dining_list': self.dining_list, 'reminder': request.user}
+
+            users = User.objects.filter(diningentry__in=unpaid_guest_entries).distinct()
+
+            for user in users:
+                guests = []
+
+                for external_entry in unpaid_guest_entries.filter(user=user):
+                    guests.append(external_entry.name)
+
+                # Call a different message if a the user added multiple guests who hadn't paid
+                if len(guests) == 1:
+                    context["guest"] = guests[0]
+                    context["guests"] = None
+                    send_templated_mail(subject=subject,
+                                        template_name=template,
+                                        context_data=context,
+                                        recipient=user)
+                else:
+                    context["guest"] = None
+                    context["guests"] = guests
+                    send_templated_mail(subject=subject,
+                                        template_name=template,
+                                        context_data=context,
+                                        recipient=user)
+
+            is_informed = True
+
+        if is_informed:
+            success_message = "Diners have been informed"
+            messages.success(request, _(success_message))
+        else:
+            inform_message = "There was nobody to inform, everybody has paid"
+            messages.info(request, _(inform_message))
+
+        return HttpResponseRedirect(self.base_redirect)

--- a/assets/mails/dining/dining_list_payment_reminder.html
+++ b/assets/mails/dining/dining_list_payment_reminder.html
@@ -30,9 +30,11 @@
             {{dining_list.association}}
         </td></tr>
     </table>
-    <p>
-        However, according to our administration, you have not yet paid for the meal itself.
-    </p>
+    {% if is_reminder %}
+        <p>
+            However, according to our administration, you have not yet paid for the meal itself.
+        </p>
+    {% endif %}
     <p>
         {{ reminder }} kindly asks you if you could pay
         {% if dining_list.dining_cost %}

--- a/assets/mails/dining/dining_list_payment_reminder.html
+++ b/assets/mails/dining/dining_list_payment_reminder.html
@@ -1,0 +1,64 @@
+{% extends 'base.html' %}
+{% load dining_tags %}
+
+{% block content %}
+    <p>
+        Hi {{ user.first_name }}
+    </p>
+    <p>
+        You recently dined with the following dining_list:
+    </p>
+    <table>
+        <tr><td>
+            Date
+        </td><td>
+            {{dining_list.date}}
+        </td></tr>
+        <tr><td>
+            Dish
+        </td><td>
+            {{dining_list.dish}}
+        </td></tr>
+        <tr><td>
+            By
+        </td><td>
+            {{dining_list|short_owners_string}}
+        </td></tr>
+        <tr><td>
+            Association
+        </td><td>
+            {{dining_list.association}}
+        </td></tr>
+    </table>
+    <p>
+        However, according to our administration, you have not yet paid for the meal itself.
+    </p>
+    <p>
+        {{ reminder }} kindly asks you if you could pay
+        {% if dining_list.dining_cost %}
+            €{{dining_list.dining_cost}}
+        {% else %}
+            your share
+        {% endif %}
+    </p>
+    {% if dining_list.payment_link %}
+    <div>
+            You can do that here:<br>
+        <a href="{{ dining_list.payment_link }}"
+           style="background-color: #375a7f;padding: 0.75em; border-radius: 0.25rem; color: white; text-decoration: none;">
+            Pay dining list</a>
+    </div>
+    {%endif%}
+    <p>
+        For more information check the dining list here:
+        <a href="{{ dining_list.get_absolute_url|to_full_url }}"
+           style="background-color: #375a7f;padding: 0.75em; border-radius: 0.25rem; color: white; text-decoration: none;">
+            {{ dining_list.get_absolute_url|to_full_url }}</a>
+    </p>
+
+
+    <p style="padding-top: 1em">
+        Enjoy your day
+    </p>
+
+{% endblock %}

--- a/assets/mails/dining/dining_list_payment_reminder.txt
+++ b/assets/mails/dining/dining_list_payment_reminder.txt
@@ -1,0 +1,21 @@
+{% extends 'base.txt' %}
+{% load dining_tags %}
+
+{% block content %}
+Hi {{user.first_name}}
+
+You recently dined with the following dining_list:
+Date: {{dining_list.date}}
+Dish: {{dining_list.dish}}
+By: {{dining_list|short_owners_string}}
+On behalf of: {{dining_list.association}}
+
+However, according to our administration, you have not yet paid for the meal itself.
+{{ reminder }} kindly asks you if you could pay{% if dining_list.dining_cost %}€ {{dining_list.dining_cost}} {% else %} your share{%endif%}.
+{% if dining_list.payment_link %}
+You can do that here:
+{{ dining_list.payment_link }}
+{%endif%}
+
+Enjoy your day!
+{% endblock %}

--- a/assets/mails/dining/dining_list_payment_reminder.txt
+++ b/assets/mails/dining/dining_list_payment_reminder.txt
@@ -10,7 +10,7 @@ Dish: {{dining_list.dish}}
 By: {{dining_list|short_owners_string}}
 On behalf of: {{dining_list.association}}
 
-However, according to our administration, you have not yet paid for the meal itself.
+{% if is_reminder %}However, according to our administration, you have not yet paid for the meal itself.{%endif%}
 {{ reminder }} kindly asks you if you could pay{% if dining_list.dining_cost %}€ {{dining_list.dining_cost}} {% else %} your share{%endif%}.
 {% if dining_list.payment_link %}
 You can do that here:

--- a/assets/mails/dining/dining_list_payment_reminder_external.html
+++ b/assets/mails/dining/dining_list_payment_reminder_external.html
@@ -1,0 +1,76 @@
+{% extends 'base.html' %}
+{% load dining_tags %}
+
+{% block content %}
+    <p>
+        Hi {{ user.first_name }}
+    </p>
+    <p>
+        {% if guest %} Your guest {{guest}} recently dined on the following dining_list:
+        {%else%}
+            You recently added  a couple of guests to the following dining list:
+        {%endif%}
+    </p>
+    <table>
+        <tr><td>
+            Date
+        </td><td>
+            {{dining_list.date}}
+        </td></tr>
+        <tr><td>
+            Dish
+        </td><td>
+            {{dining_list.dish}}
+        </td></tr>
+        <tr><td>
+            By
+        </td><td>
+            {{dining_list|short_owners_string}}
+        </td></tr>
+        <tr><td>
+            Association
+        </td><td>
+            {{dining_list.association}}
+        </td></tr>
+    </table>
+    <p>
+        However, according to our administration,
+        {% if guest %} {{ guest }} has not paid for the meal yet.{% else %}
+            Some of them have not yet paid for the meal yet.
+        {% endif %}
+    </p>
+    <p>
+        {% if guest %}
+            {{ reminder }} kindly ask you to contact him/her and ask him to pay for the meal.
+        {% else %}
+            {{ reminder }} kindly asks you to contact the following guests:
+            <li>
+            {% for guest in guests %}
+                <ul>{{guest}}</ul>
+            {%endfor%}
+            </li>
+        {%endif%}
+    </p>
+    {% if dining_list.payment_link %}
+    <div>
+            Paying can be done here:<br>
+        {% with url=dining_list.get_absolute_url|to_full_url %}
+        <a href="{{ url }}"
+           style="">
+            {{ url }}</a>
+        {% endwith %}
+    </div>
+    {%endif%}
+    <p>
+        For more information check the dining list here:
+        <a href="{{ dining_list.get_absolute_url|to_full_url }}"
+           style="background-color: #375a7f;padding: 0.75em; border-radius: 0.25rem; color: white; text-decoration: none;">
+            To dining list</a>
+    </p>
+
+
+    <p style="padding-top: 1em">
+        Enjoy your day
+    </p>
+
+{% endblock %}

--- a/assets/mails/dining/dining_list_payment_reminder_external.html
+++ b/assets/mails/dining/dining_list_payment_reminder_external.html
@@ -34,14 +34,16 @@
         </td></tr>
     </table>
     <p>
-        However, according to our administration,
-        {% if guest %} {{ guest }} has not paid for the meal yet.{% else %}
-            Some of them have not yet paid for the meal yet.
+        {% is_reminder %}
+            However, according to our administration,
+            {% if guest %} {{ guest }} has not paid for the meal yet.{% else %}
+                Some of them have not yet paid for the meal yet.
+            {% endif %}
         {% endif %}
     </p>
     <p>
         {% if guest %}
-            {{ reminder }} kindly ask you to contact him/her and ask him to pay for the meal.
+            {{ reminder }} kindly ask you to contact {{ guest }} and ask him to pay for the meal.
         {% else %}
             {{ reminder }} kindly asks you to contact the following guests:
             <li>

--- a/assets/mails/dining/dining_list_payment_reminder_external.txt
+++ b/assets/mails/dining/dining_list_payment_reminder_external.txt
@@ -12,7 +12,9 @@
     By: {{dining_list|short_owners_string}}
     On behalf of: {{dining_list.association}}
 
+    {% is_reminder %}
     However, according to our administration, {% if guest %} {{ guest }} has not paid for the meal yet. {%else%} Some of them have not paid for their meal yet {%endif%}
+    {% endif %}
 
     {% if guest %}
         {{ reminder }} kindly ask you to contact him/her and ask him to pay for the meal.

--- a/assets/mails/dining/dining_list_payment_reminder_external.txt
+++ b/assets/mails/dining/dining_list_payment_reminder_external.txt
@@ -1,0 +1,30 @@
+{% extends 'base.txt' %}
+{% load dining_tags %}
+
+{% block content %}
+    Hi {{user.first_name}}
+
+    {% if guest %} Your guest {{guest}} recently dined on the following dining_list:
+    {%else%} You recently added  a couple of guests to the following dining list:
+    {%endif%}
+    Date: {{dining_list.date}}
+    Dish: {{dining_list.dish}}
+    By: {{dining_list|short_owners_string}}
+    On behalf of: {{dining_list.association}}
+
+    However, according to our administration, {% if guest %} {{ guest }} has not paid for the meal yet. {%else%} Some of them have not paid for their meal yet {%endif%}
+
+    {% if guest %}
+        {{ reminder }} kindly ask you to contact him/her and ask him to pay for the meal.
+    {% else %}
+        {{ reminder }} kindly asks you to contact the following guests:
+        {% for guest in guests %}
+            {{guest}}
+        {%endfor%}
+    {%endif%}
+
+    For more information, check the dining list here:
+    {{ dining_list.get_absolute_url|to_full_url }}
+
+    Enjoy your day!
+{% endblock %}

--- a/assets/templates/dining_lists/dining_slot_diners.html
+++ b/assets/templates/dining_lists/dining_slot_diners.html
@@ -152,7 +152,24 @@
                             <button type="submit" class="btn btn-block btn-primary" form="statsForm">
                                 Update User Stats
                             </button>
+                            <form method="post" class="mt-3"
+                                  action="{% url 'slot_inform_payment' day=date.day month=date.month year=date.year identifier=dining_list.association.slug %}">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-block btn-secondary">
+                                    <div class="badge badge-info" style="position: center">new</div>
+                                    <span class="">Send payment reminder <i class="fas fa-envelope"></i></span>
+                                </button>
+                                <small>Sends a mail to all who have not yet paid with a reminder</small>
+                            </form>
                         {% endif %}
+                    </td>
+                    <td><div></div></td>
+
+                </tr>
+                <tr>
+                    <td><div></div></td>
+                    <td>
+
                     </td>
                     <td></td>
                 </tr>
@@ -173,7 +190,6 @@
                 {% url 'entry_add' day=date.day month=date.month year=date.year identifier=dining_list.association.slug %}">
                    + Add Diner</a>
            {% endif %}
-
         </div>
     </div>
 

--- a/assets/templates/dining_lists/dining_slot_diners.html
+++ b/assets/templates/dining_lists/dining_slot_diners.html
@@ -152,15 +152,17 @@
                             <button type="submit" class="btn btn-block btn-primary" form="statsForm">
                                 Update User Stats
                             </button>
+                            {% if dining_list.payment_link %}
                             <form method="post" class="mt-3"
                                   action="{% url 'slot_inform_payment' day=date.day month=date.month year=date.year identifier=dining_list.association.slug %}">
                                 {% csrf_token %}
                                 <button type="submit" class="btn btn-block btn-secondary">
                                     <div class="badge badge-info" style="position: center">new</div>
-                                    <span class="">Send payment reminder <i class="fas fa-envelope"></i></span>
+                                    <span class="">Send payment mail <i class="fas fa-envelope"></i></span>
                                 </button>
                                 <small>Sends a mail to all who have not yet paid with a reminder</small>
                             </form>
+                            {% endif %}
                         {% endif %}
                     </td>
                     <td><div></div></td>
@@ -184,6 +186,17 @@
                 <button type="submit" class="btn btn-block btn-primary" form="statsForm">
                     Update User Stats
                 </button>
+                {% if dining_list.payment_link %}
+                    <form method="post" class="mt-3"
+                          action="{% url 'slot_inform_payment' day=date.day month=date.month year=date.year identifier=dining_list.association.slug %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-block btn-secondary">
+                            <div class="badge badge-info" style="position: center">new</div>
+                            <span class="">Send payment mail <i class="fas fa-envelope"></i></span>
+                        </button>
+                        <small>Sends a mail to all who have not yet paid with a reminder</small>
+                    </form>
+                {% endif %}
             {% endif %}
            {% if dining_list|can_add_others:user %}
                <a class="btn btn-primary btn-block" href="


### PR DESCRIPTION
Linked from the diners page,  you can now send automatic mails to all who hadn't paid yet. It takes into account internal and external entries seperately