### PR TITLE
Fix tests and linter comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ inside the virtual environment
 and run `pip-compile requirements.in`.
 See [pip-tools documentation](https://github.com/jazzband/pip-tools)
 for details.
+
+## Code style
+
+The linter Flake8 expects the code, including docstrings, to follow the
+[Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
+See the file `.flake8` for the exact configuration.
+
+To let PyCharm use the correct docstring format, change the setting at
+"Tools -> Python Integrated Tools -> Docstrings -> Docstring format" to Google.

--- a/dining/forms.py
+++ b/dining/forms.py
@@ -14,10 +14,9 @@ from django.utils import timezone
 from creditmanagement.models import Transaction, Account
 from dining.models import DiningList, DiningEntryUser, DiningEntryExternal, DiningComment, DiningEntry
 from general.forms import ConcurrenflictFormMixin
-from general.util import SelectWithDisabled
 from general.mail_control import send_templated_mail
+from general.util import SelectWithDisabled
 from userdetails.models import Association, UserMembership, User
-
 
 __all__ = ['CreateSlotForm', 'DiningInfoForm', 'DiningPaymentForm', 'DiningEntryUserCreateForm',
            'DiningEntryExternalCreateForm', 'DiningEntryDeleteForm', 'DiningListDeleteForm',
@@ -374,7 +373,7 @@ class DiningCommentForm(forms.ModelForm):
 
 class SendReminderForm(forms.Form):
 
-    def __init__(self, *args, dining_list: DiningList=None, **kwargs):
+    def __init__(self, *args, dining_list: DiningList = None, **kwargs):
         assert dining_list is not None
         self.dining_list = dining_list
         super(SendReminderForm, self).__init__(*args, **kwargs)

--- a/dining/tests/test_forms.py
+++ b/dining/tests/test_forms.py
@@ -1,17 +1,17 @@
-from datetime import time, timedelta, datetime
+from datetime import timedelta, datetime, time
 from decimal import Decimal
 
 from dal_select2.widgets import ModelSelect2, ModelSelect2Multiple
-
 from django.conf import settings
 from django.forms import ModelForm
+from django.http import HttpRequest
 from django.test import TestCase
 from django.utils import timezone
-from django.http import HttpRequest
 
-from creditmanagement.models import Transaction, Account
-from dining.forms import *
-from dining.models import *
+from creditmanagement.models import Account, Transaction
+from dining.forms import CreateSlotForm, DiningEntryUserCreateForm, DiningEntryExternalCreateForm, \
+    DiningEntryDeleteForm, DiningInfoForm, DiningPaymentForm, DiningCommentForm, SendReminderForm, DiningListDeleteForm
+from dining.models import DiningList, DiningEntryUser, DiningEntryExternal, DiningEntry, DiningComment
 from general.forms import ConcurrenflictFormMixin
 from userdetails.models import Association, User, UserMembership
 from utils.testing import TestPatchMixin, patch, FormValidityMixin
@@ -122,14 +122,14 @@ class TestDiningEntryUserCreateForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_form_valid(self):
-        """ Asserts that the testing environment standard is valid """
+        """Asserts that the testing environment standard is valid."""
         # Check for self creation, useful to guarantee a baseline of current testing environment
-        self.assertFormValid({'user': self.user})
+        self.assert_form_valid({'user': self.user})
 
     @patch_time()
     def test_entry_db_creation(self):
-        """ Tests the database object creation for an entry"""
-        form = self.assertFormValid({'user': User.objects.get(id=4)})
+        """Tests the database object creation for an entry."""
+        form = self.assert_form_valid({'user': User.objects.get(id=4)})
         instance = form.save()
 
         self.assertTrue(DiningEntryUser.objects.filter(id=instance.id).exists())
@@ -139,7 +139,7 @@ class TestDiningEntryUserCreateForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_transation_db_creation(self):
-        """ Asserts that the correct transaction is created"""
+        """Asserts that the correct transaction is created."""
         # Adjust kitchen cost so we can test it takes that value
         self.dining_list.kitchen_cost = 0.42
         self.dining_list.save()
@@ -147,7 +147,7 @@ class TestDiningEntryUserCreateForm(FormValidityMixin, TestCase):
         added_user = User.objects.get(id=4)
 
         # Save the instance
-        form = self.assertFormValid({'user': added_user})
+        form = self.assert_form_valid({'user': added_user})
         instance = form.save()
 
         self.assertIsNotNone(instance.transaction)
@@ -163,19 +163,19 @@ class TestDiningEntryUserCreateForm(FormValidityMixin, TestCase):
             user=self.user,
             created_by=self.user
         )
-        self.assertFormHasError({'user': self.user}, code='user_already_present')
+        self.assert_form_has_error({'user': self.user}, code='user_already_present')
 
     @patch_time(dt=datetime(2022, 4, 26, 18, 0))
     def test_sign_up_deadline(self):
-        """ Asserts that the form can not be used after the timelimit """
+        """Asserts that the form can not be used after the timelimit."""
         # Verify testcase data
         self.assertNotIn(self.user, self.dining_list.owners.all(), "Incorrect test data, user should not be owner")
-        self.assertFormHasError({'user': self.user}, code='closed')
-        self.assertFormValid({'user': self.user}, created_by=self.dining_list.owners.first())
+        self.assert_form_has_error({'user': self.user}, code='closed')
+        self.assert_form_valid({'user': self.user}, created_by=self.dining_list.owners.first())
 
     @patch_time()
     def test_room(self):
-        """ Asserts that the form can not be used after the timelimit """
+        """Asserts that the form can not be used after the timelimit."""
         # Verify testcase data
         self.assertNotIn(self.user, self.dining_list.owners.all(), "Incorrect test data, user should not be owner")
         # Fill the dininglist with meaningless entries
@@ -184,36 +184,36 @@ class TestDiningEntryUserCreateForm(FormValidityMixin, TestCase):
             DiningEntryExternal.objects.create(dining_list=self.dining_list, user=other_user, created_by=other_user)
         self.dining_list.max_diners = 14
 
-        self.assertFormHasError({'user': self.user}, code='full')
-        self.assertFormValid({'user': self.user}, created_by=self.dining_list.owners.first())
+        self.assert_form_has_error({'user': self.user}, code='full')
+        self.assert_form_valid({'user': self.user}, created_by=self.dining_list.owners.first())
 
     @patch_time()
     def test_association_only_limitation(self):
-        """ Asserts that the form can not be used after the timelimit """
+        """Asserts that the form can not be used after the timelimit."""
         # Verify testcase data
         self.dining_list.limit_signups_to_association_only = True
         self.dining_list.save()
         self.assertNotIn(self.user, self.dining_list.owners.all(), "Incorrect test data, user should not be owner")
         # user 2 is member of the association
-        self.assertFormValid({'user': self.user})
+        self.assert_form_valid({'user': self.user})
         # user 4 is not a member
-        self.assertFormHasError({'user': User.objects.get(id=4)}, code='members_only')
+        self.assert_form_has_error({'user': User.objects.get(id=4)}, code='members_only')
         # owners can override
-        self.assertFormValid({'user': User.objects.get(id=4)}, created_by=self.dining_list.owners.first())
+        self.assert_form_valid({'user': User.objects.get(id=4)}, created_by=self.dining_list.owners.first())
 
     @patch_time()
     def test_minimum_balance(self):
         with self.settings(MINIMUM_BALANCE_FOR_DINING_SIGN_UP=100):
             # For minimum balance, nobody has an exception, not even admins
-            self.assertFormHasError({'user': self.user}, code='nomoneyzz')
-            self.assertFormHasError({'user': self.user}, created_by=self.dining_list.owners.first(), code='nomoneyzz')
+            self.assert_form_has_error({'user': self.user}, code='nomoneyzz')
+            self.assert_form_has_error({'user': self.user}, created_by=self.dining_list.owners.first(), code='nomoneyzz')
             admin = User.objects.filter(is_superuser=True).first()
-            self.assertFormHasError({'user': admin}, created_by=admin, code='nomoneyzz')
+            self.assert_form_has_error({'user': admin}, created_by=admin, code='nomoneyzz')
 
     @patch_time(dt=datetime(2022, 5, 30, 12, 0))
     def test_form_editing_time_limit(self):
-        """ Asserts that the form can not be used after the timelimit """
-        self.assertFormHasError({'user': self.user}, code='closed')
+        """Asserts that the form can not be used after the timelimit."""
+        self.assert_form_has_error({'user': self.user}, code='closed')
 
 
 class TestDiningEntryExternalCreateForm(FormValidityMixin, TestCase):
@@ -231,14 +231,14 @@ class TestDiningEntryExternalCreateForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_form_valid(self):
-        """ Asserts that the testing environment standard is valid """
+        """Asserts that the testing environment standard is valid."""
         # Check for self creation, useful to guarantee a baseline of current testing environment
-        self.assertFormValid({'name': 'my_guest'})
+        self.assert_form_valid({'name': 'my_guest'})
 
     @patch_time()
     def test_entry_db_creation(self):
-        """ Tests the database object creation for an entry"""
-        form = self.assertFormValid({'name': 'my guest'})
+        """Tests the database object creation for an entry."""
+        form = self.assert_form_valid({'name': 'my guest'})
         instance = form.save()
 
         self.assertTrue(DiningEntryExternal.objects.filter(id=instance.id).exists())
@@ -249,13 +249,13 @@ class TestDiningEntryExternalCreateForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_transation_db_creation(self):
-        """ Asserts that the correct transaction is created"""
+        """Asserts that the correct transaction is created."""
         # Adjust kitchen cost so we can test it takes that value
         self.dining_list.kitchen_cost = 0.37
         self.dining_list.save()
 
         # Save the instance
-        form = self.assertFormValid({'name': 'my guest'})
+        form = self.assert_form_valid({'name': 'my guest'})
         instance = form.save()
 
         self.assertIsNotNone(instance.transaction)
@@ -266,15 +266,13 @@ class TestDiningEntryExternalCreateForm(FormValidityMixin, TestCase):
 
     @patch_time(dt=datetime(2022, 4, 26, 18, 0))
     def test_sign_up_deadline(self):
-        """ Asserts that the form can not be used after the timelimit """
         # Verify testcase data
         self.assertNotIn(self.user, self.dining_list.owners.all(), "Incorrect test data, user should not be owner")
-        self.assertFormHasError({'name': 'my guest'}, code='closed')
-        self.assertFormValid({'name': 'my guest'}, created_by=self.dining_list.owners.first())
+        self.assert_form_has_error({'name': 'my guest'}, code='closed')
+        self.assert_form_valid({'name': 'my guest'}, created_by=self.dining_list.owners.first())
 
     @patch_time()
     def test_room(self):
-        """ Asserts that the form can not be used after the timelimit """
         # Verify testcase data
         self.assertNotIn(self.user, self.dining_list.owners.all(), "Incorrect test data, user should not be owner")
         # Fill the dininglist with meaningless entries
@@ -283,36 +281,35 @@ class TestDiningEntryExternalCreateForm(FormValidityMixin, TestCase):
             DiningEntryExternal.objects.create(dining_list=self.dining_list, user=other_user, created_by=other_user)
         self.dining_list.max_diners = 14
 
-        self.assertFormHasError({'name': 'my guest'}, code='full')
-        self.assertFormValid({'name': 'my guest'}, created_by=self.dining_list.owners.first())
+        self.assert_form_has_error({'name': 'my guest'}, code='full')
+        self.assert_form_valid({'name': 'my guest'}, created_by=self.dining_list.owners.first())
 
     @patch_time()
     def test_association_only_limitation(self):
-        """ Asserts that the form can not be used after the timelimit """
         # Verify testcase data
         self.dining_list.limit_signups_to_association_only = True
         self.dining_list.save()
         self.assertNotIn(self.user, self.dining_list.owners.all(), "Incorrect test data, user should not be owner")
         # user 2 is member of the association
-        self.assertFormValid({'name': 'my guest'})
+        self.assert_form_valid({'name': 'my guest'})
         # user 4 is not a member
-        self.assertFormHasError({'name': 'my guest'}, code='members_only', created_by=User.objects.get(id=4))
+        self.assert_form_has_error({'name': 'my guest'}, code='members_only', created_by=User.objects.get(id=4))
         # owners can override
-        self.assertFormValid({'name': 'my guest'}, created_by=self.dining_list.owners.first())
+        self.assert_form_valid({'name': 'my guest'}, created_by=self.dining_list.owners.first())
 
     @patch_time()
     def test_minimum_balance(self):
         with self.settings(MINIMUM_BALANCE_FOR_DINING_SIGN_UP=100):
             # For minimum balance, nobody has an exception, not even admins
-            self.assertFormHasError({'name': 'my guest'}, code='nomoneyzz')
-            self.assertFormHasError({'name': 'my guest'}, created_by=self.dining_list.owners.first(), code='nomoneyzz')
+            self.assert_form_has_error({'name': 'my guest'}, code='nomoneyzz')
+            self.assert_form_has_error({'name': 'my guest'}, created_by=self.dining_list.owners.first(), code='nomoneyzz')
             admin = User.objects.filter(is_superuser=True).first()
-            self.assertFormHasError({'name': 'my guest'}, created_by=admin, code='nomoneyzz')
+            self.assert_form_has_error({'name': 'my guest'}, created_by=admin, code='nomoneyzz')
 
     @patch_time(dt=datetime(2022, 5, 30, 12, 0))
     def test_form_editing_time_limit(self):
-        """ Asserts that the form can not be used after the timelimit """
-        self.assertFormHasError({'name': 'my guest'}, code='closed')
+        """Asserts that the form can not be used after the timelimit."""
+        self.assert_form_has_error({'name': 'my guest'}, code='closed')
 
 
 class TestDiningEntryDeleteForm(FormValidityMixin, TestCase):
@@ -331,21 +328,20 @@ class TestDiningEntryDeleteForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_form_valid(self):
-        """ Asserts that the testing environment standard is valid """
-        self.assertFormValid({})
+        self.assert_form_valid({})
         # Test an external user that this user added
-        self.assertFormValid({}, entry=DiningEntryExternal.objects.get(id=4))
+        self.assert_form_valid({}, entry=DiningEntryExternal.objects.get(id=4))
 
     @patch_time()
     def test_db_entry_deletion(self):
-        form = self.assertFormValid({})
+        form = self.assert_form_valid({})
         form.execute()
 
         self.assertFalse(DiningEntry.objects.filter(id=self.entry.id).exists())
 
     @patch_time(dt=datetime(2022, 4, 26, 14, 23))
     def test_db_transacton_deletion(self):
-        self.assertFormValid({}).execute()
+        self.assert_form_valid({}).execute()
         self.entry.transaction.refresh_from_db()
 
         self.assertEqual(self.entry.transaction.cancelled, timezone.make_aware(datetime(2022, 4, 26, 14, 23)))
@@ -353,20 +349,20 @@ class TestDiningEntryDeleteForm(FormValidityMixin, TestCase):
 
     @patch_time(dt=datetime(2022, 4, 26, 18, 0))
     def test_sign_up_deadline(self):
-        """ Asserts that the form can not be used after the sign-upl deadline unless owner """
+        """Asserts that the form can not be used after the sign-up deadline unless owner."""
         # Verify testcase data
         self.assertNotIn(self.user, self.dining_list.owners.all(), "Incorrect test data, user should not be owner")
-        self.assertFormHasError({}, code='closed')
-        self.assertFormValid({}, deleter=self.dining_list.owners.first())
+        self.assert_form_has_error({}, code='closed')
+        self.assert_form_valid({}, deleter=self.dining_list.owners.first())
 
     @patch_time()
     def test_ownership(self):
-        self.assertFormHasError({}, code='not_owner', deleter=User.objects.get(id=5))
+        self.assert_form_has_error({}, code='not_owner', deleter=User.objects.get(id=5))
 
     @patch_time(dt=datetime(2022, 5, 30, 12, 0))
     def test_form_editing_time_limit(self):
-        """ Asserts that the form can not be used after the timelimit """
-        self.assertFormHasError({}, code='locked')
+        """Asserts that the form can not be used after the timelimit."""
+        self.assert_form_has_error({}, code='locked')
 
 
 class TestDiningListDeleteForm(FormValidityMixin, TestCase):
@@ -384,24 +380,24 @@ class TestDiningListDeleteForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_form_valid(self):
-        """ Asserts that the testing environment standard is valid """
-        self.assertFormValid({})
+        """Asserts that the testing environment standard is valid."""
+        self.assert_form_valid({})
 
     @patch_time()
     def test_db_list_deletion(self):
         dining_list_id = self.dining_list.id
-        self.assertFormValid({}).execute()
+        self.assert_form_valid({}).execute()
 
         self.assertFalse(DiningEntryUser.objects.filter(dining_list__id=dining_list_id).exists())
         self.assertFalse(DiningEntryExternal.objects.filter(dining_list__id=dining_list_id).exists())
 
     @patch_time()
     def test_db_transaction_cancellation(self):
-        """ Tests that the correct transactions are cancelled """
+        """Tests that the correct transactions are cancelled."""
         diner_count = self.dining_list.dining_entries.count()
         old_cancelled_transaction_count = Transaction.objects.filter(cancelled__isnull=False).count()
 
-        self.assertFormValid({}).execute()
+        self.assert_form_valid({}).execute()
 
         # Ensure that the
         self.assertEqual(
@@ -412,12 +408,12 @@ class TestDiningListDeleteForm(FormValidityMixin, TestCase):
     @patch_time()
     def test_owner_deletion(self):
         self.dining_list.owners.clear()
-        self.assertFormHasError({}, code="not_owner")
+        self.assert_form_has_error({}, code="not_owner")
 
     @patch_time(dt=datetime(2022, 5, 30, 12, 0))
     def test_form_editing_time_limit(self):
-        """ Asserts that the form can not be used after the timelimit """
-        self.assertFormHasError({}, code='locked')
+        """Asserts that the form can not be used after the timelimit."""
+        self.assert_form_has_error({}, code='locked')
 
 
 class TestDiningInfoForm(FormValidityMixin, TestCase):
@@ -442,7 +438,7 @@ class TestDiningInfoForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_form_valid(self):
-        self.assertFormValid({
+        self.assert_form_valid({
             'owners': [1],
             'dish': "My delicious dish",
             'serve_time': time(18, 00),
@@ -453,7 +449,7 @@ class TestDiningInfoForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_db_update(self):
-        updated_dining_list = self.assertFormValid({
+        updated_dining_list = self.assert_form_valid({
             'owners': [4],
             'dish': "New dish",
             'serve_time': time(17, 5),
@@ -475,22 +471,22 @@ class TestDiningInfoForm(FormValidityMixin, TestCase):
 
     @patch_time(dt=datetime(2022, 5, 30, 12, 0))
     def test_form_editing_time_limit(self):
-        """ Asserts that the form can not be used after the timelimit """
-        self.assertFormHasError({}, code='closed')
+        """Asserts that the form can not be used after the timelimit."""
+        self.assert_form_has_error({}, code='closed')
 
     @patch_time()
     def test_kitchen_open_time_validity(self):
-        """ Asserts that the meal can't be served before the kitchen opening time """
+        """Asserts that the meal can't be served before the kitchen opening time."""
         dt = datetime.combine(timezone.now().today(), settings.KITCHEN_USE_START_TIME) - timedelta(minutes=1)
-        self.assertFormHasError({
+        self.assert_form_has_error({
             'serve_time': dt.time()
         }, code='kitchen_start_time')
 
     @patch_time()
     def test_kitchen_close_time_validity(self):
-        """ Asserts that the meal can't be served after the kitchen closing time """
+        """Asserts that the meal can't be served after the kitchen closing time."""
         dt = datetime.combine(timezone.now().today(), settings.KITCHEN_USE_END_TIME) + timedelta(minutes=1)
-        self.assertFormHasError({
+        self.assert_form_has_error({
             'serve_time': dt.time()
         }, code='kitchen_close_time')
 
@@ -513,40 +509,40 @@ class TestDiningPaymentForm(FormValidityMixin, TestCase):
 
     @patch_time()
     def test_form_valid(self):
-        self.assertFormValid({
+        self.assert_form_valid({
             'payment_link': "https://www.google.com/",
         })
-        self.assertFormValid({})
+        self.assert_form_valid({})
 
     @patch_time()
     def test_dining_cost_conflict(self):
-        """ Assert that an error is raised when both dinner_cost and dinner_cost_total are defined """
-        self.assertFormHasError({
+        """Assert that an error is raised when both dinner_cost and dinner_cost_total are defined."""
+        self.assert_form_has_error({
             'dining_cost_total': 12,
             'dining_cost': 4,
         }, code='duplicate_cost', field='dining_cost')
-        self.assertFormHasError({
+        self.assert_form_has_error({
             'dining_cost_total': 12,
             'dining_cost': 4,
         }, code='duplicate_cost', field='dining_cost_total')
 
     @patch_time()
     def test_dining_cost_total_empty_diners(self):
-        """ Assert an error is raised for costs when there are no diners on the dining list """
+        """Assert an error is raised for costs when there are no diners on the dining list."""
         self.dining_list.dining_entries.all().delete()
-        self.assertFormHasError({
+        self.assert_form_has_error({
             'dining_cost_total': 12,
         }, code='costs_no_diners')
 
     @patch_time()
     def test_dining_cost_total(self):
-        """ Test that dining cost is correctly computed from total cost """
-        form = self.assertFormValid({'dining_cost_total': 16})
+        """Test that dining cost is correctly computed from total cost."""
+        form = self.assert_form_valid({'dining_cost_total': 16})
         self.assertIsNone(form.cleaned_data['dining_cost_total'])
         self.assertEqual(form.cleaned_data['dining_cost'], 2)
 
         # Test that it rounds up
-        form = self.assertFormValid({'dining_cost_total': 15.95})
+        form = self.assert_form_valid({'dining_cost_total': 15.95})
         self.assertIsNone(form.cleaned_data['dining_cost_total'])
         self.assertEqual(form.cleaned_data['dining_cost'], 2)
 
@@ -565,9 +561,9 @@ class TestDiningCommentForm(FormValidityMixin, TestCase):
         return super(TestDiningCommentForm, self).get_form_kwargs(**kwargs)
 
     def test_valid(self):
-        """ Tests basic validity functionality """
+        """Tests basic validity functionality."""
         posted_msg = 'My very message'
-        form = self.assertFormValid({'message': posted_msg})
+        form = self.assert_form_valid({'message': posted_msg})
         form.save()
 
         # Assert copy on database:
@@ -579,9 +575,9 @@ class TestDiningCommentForm(FormValidityMixin, TestCase):
         self.assertEqual(form.instance.pinned_to_top, False)
 
     def test_pinning(self):
-        """ Tests that a message can be pinned """
+        """Tests that a message can be pinned."""
         posted_msg = "A stickied message"
-        form = self.assertFormValid({'message': posted_msg}, pinned=True)
+        form = self.assert_form_valid({'message': posted_msg}, pinned=True)
         form.save()
         self.assertEqual(form.instance.pinned_to_top, True)
 
@@ -598,22 +594,22 @@ class TestSendReminderForm(FormValidityMixin, TestPatchMixin, TestCase):
         self.dining_list = DiningList.objects.get(id=1)
 
     def test_is_valid(self):
-        """ Tests that the form is normally valid"""
-        self.assertFormValid({})
+        """Tests that the form is normally valid."""
+        self.assert_form_valid({})
 
     def test_invalid_all_paid(self):
         # Make all users paid
         self.dining_list.dining_entries.update(has_paid=True)
-        self.assertFormHasError({}, code='all_paid')
+        self.assert_form_has_error({}, code='all_paid')
 
     def test_invalid_missing_payment_link(self):
         self.dining_list.payment_link = ""
         self.dining_list.save()
-        self.assertFormHasError({}, code='payment_url_missing')
+        self.assert_form_has_error({}, code='payment_url_missing')
 
     @patch('dining.forms.send_templated_mail')
     def test_no_unpaid_users_sending(self, mock_mail):
-        """ Assert that when all users have paid, no mails are send to remind people"""
+        """Asserts that when all users have paid, no mails are send to remind people."""
         DiningEntryUser.objects.update(has_paid=True)
         DiningEntryExternal.objects.all().delete()
         form = self.build_form({})
@@ -624,21 +620,8 @@ class TestSendReminderForm(FormValidityMixin, TestPatchMixin, TestCase):
         mock_mail.assert_not_called()
 
     @patch('dining.forms.send_templated_mail')
-    def test_no_unpaid_users_sending(self, mock_mail):
-        """ Assert that when all users have paid, no mails are send to remind people"""
-        DiningEntryExternal.objects.update(has_paid=True)
-        DiningEntryUser.objects.all().delete()
-        form = self.build_form({})
-        request = HttpRequest()
-        request.user = User.objects.get(id=1)
-        form.send_reminder(request=request)
-
-        mock_mail.assert_not_called()
-
-    @patch('dining.forms.send_templated_mail')
     def test_mail_sending_users(self, mock_mail):
-
-        form = self.assertFormValid({})
+        form = self.assert_form_valid({})
         request = HttpRequest()
         request.user = User.objects.get(id=1)
         form.send_reminder(request=request)
@@ -658,9 +641,8 @@ class TestSendReminderForm(FormValidityMixin, TestPatchMixin, TestCase):
 
     @patch('dining.forms.send_templated_mail')
     def test_mail_sending_external(self, mock_mail):
-        """ Tests handling of messaging for external guests added by a certain user"""
-
-        form = self.assertFormValid({})
+        """Tests handling of messaging for external guests added by a certain user."""
+        form = self.assert_form_valid({})
         request = HttpRequest()
         request.user = User.objects.get(id=1)
         form.send_reminder(request=request)

--- a/dining/tests/testformsdiningentry.py
+++ b/dining/tests/testformsdiningentry.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from creditmanagement.models import Transaction
 from dining.forms import DiningEntryUserCreateForm, DiningEntryDeleteForm, DiningEntryExternalCreateForm
-from dining.models import DiningList, DiningEntryUser, DiningEntryExternal
+from dining.models import DiningList, DiningEntryUser
 from userdetails.models import User, Association, UserMembership
 
 

--- a/dining/views.py
+++ b/dining/views.py
@@ -18,8 +18,7 @@ from django.views.generic.edit import DeleteView
 from dining.datesequence import sequenced_date
 from dining.forms import CreateSlotForm, DiningEntryUserCreateForm, DiningEntryExternalCreateForm, \
     DiningEntryDeleteForm, DiningCommentForm, DiningInfoForm, DiningPaymentForm, DiningListDeleteForm, SendReminderForm
-from dining.models import DiningList, DiningDayAnnouncement, DiningCommentVisitTracker, DiningEntryExternal, \
-    DiningEntryUser, DiningEntry
+from dining.models import DiningList, DiningDayAnnouncement, DiningCommentVisitTracker, DiningEntry
 from general.mail_control import send_templated_mail
 from userdetails.models import User, Association
 

--- a/utils/testing/__init__.py
+++ b/utils/testing/__init__.py
@@ -1,5 +1,5 @@
-from .form_test_utils import FormValidityMixin
-from .patch_utils import patch, TestPatchMixin
+from utils.testing.form_test_utils import FormValidityMixin
+from utils.testing.patch_utils import patch, TestPatchMixin
 
 
 __all__ = ['FormValidityMixin', 'TestPatchMixin', 'patch']

--- a/utils/testing/form_test_utils.py
+++ b/utils/testing/form_test_utils.py
@@ -1,3 +1,4 @@
+from django.forms import Form
 
 
 class FormValidityMixin:
@@ -13,24 +14,24 @@ class FormValidityMixin:
             form_class = self.form_class
         return form_class(data=data, **self.get_form_kwargs(**kwargs))
 
-    def assertHasField(self, field_name):
-        """
-        Asserts that the form has a field with the given name.
+    def assert_has_field(self, field_name):
+        """Asserts that the form has a field with the given name.
 
-        :param field_name: name of the field
-        :return: raises AssertionError if not asserted, otherwise returns empty
+        Raises:
+            AssertionError if not asserted, otherwise nothing.
         """
         form = self.build_form({})
         message = f"{field_name} was not a field in {form.__class__.__name__}"
+        # This method is provided by the TestCase class.
         self.assertIn(field_name, form.fields, msg=message)
 
-    def assertFormValid(self, data, form_class=None, **kwargs):
-        """ Asserts that the form is valid otherwise raises AssertionError mentioning the form error.
+    def assert_form_valid(self, data, form_class=None, **kwargs):
+        """Asserts that the form is valid, otherwise raises AssertionError mentioning the form error.
 
-        :param data: The form data
-        :param form_class: The form class, defaults to self.form_class
-        :param kwargs: Any form init kwargs not defined in self.build_form()
-        :return:
+        Args:
+            data: The form data.
+            form_class: The form class, defaults to self.form_class.
+            kwargs: Any form init kwargs not defined in self.build_form().
         """
         form = self.build_form(data, form_class=form_class, **kwargs)
 
@@ -44,41 +45,29 @@ class FormValidityMixin:
             raise AssertionError(fail_message)
         return form
 
-    def assertFormHasError(self, data, code, form_class=None, field=None, **kwargs):
-        """ Asserts that a form with the given data invalidates on a certain error.
+    def assert_form_has_error(self, data, code, form_class=None, field=None, **kwargs):
+        """Asserts that a form with the given data invalidates on a certain error.
 
-        :param data: The form data
-        :param code: the 'code' of the ValidationError
-        :param form_class: The form class, defaults to self.form_class
-        :param field: The field on which the validationerror needs to be, set to '__all__' if it's not form specefic
-        leave empty if not relevant.
-        :param kwargs: Any form init kwargs not defined in self.build_form()
-        :return:
+        Args:
+            data: The form data.
+            code: The 'code' of the ValidationError.
+            form_class: The form class, defaults to self.form_class.
+            field: The field on which the ValidationError needs to be, set to '__all__' if it's not a specific field.
+                Leave empty if not relevant.
+            kwargs: Any form init kwargs not defined in self.build_form().
         """
-        form = self.build_form(data, form_class=form_class, **kwargs)
+        form = self.build_form(data, form_class=form_class or self.form_class, **kwargs)  # type: Form
 
         if form.is_valid():
             raise AssertionError("The form contained no errors")
 
-        for key, value in form.errors.as_data().items():
-            if field:
-                if field != key:
-                    continue
-                for error in value:
-                    if error.code == code:
-                        return
-                raise AssertionError(f"Form did not contain an error with code '{code}' in field '{field}'")
-            else:
-                for error in value:
-                    if error.code == code:
-                        return
-
+        # Extract the applicable ValidationError instances.
         if field:
-            raise AssertionError(f"Form did not encounter an error in '{field}'.")
+            errors = form.errors.as_data().get(field, [])
+        else:
+            # Each value in form.errors is a list of ValidationError instances. We flatten this list here.
+            errors = [item for sublist in form.errors.as_data().values() for item in sublist]
 
-        error_message = f"Form did not contain an error with code '{code}'."
-        if form.errors:
-            invalidation_errors = form.errors.as_data()
-            invalidation_error = invalidation_errors[list(invalidation_errors.keys())[0]][0]
-            error_message += f" Though there was another error: '{invalidation_error}'"
-        raise AssertionError(error_message)
+        # Verify that we have an error AND that all errors have the correct code.
+        if not errors or not all((e.code == code for e in errors)):
+            raise AssertionError(f"Form did not contain an error with code '{code}', with field={field}.")

--- a/utils/testing/patch_utils.py
+++ b/utils/testing/patch_utils.py
@@ -3,7 +3,6 @@ import datetime
 from django.utils import timezone
 from unittest.mock import patch, Mock
 
-
 __all__ = ["patch", "patch_time", "mock_now"]
 
 
@@ -17,14 +16,17 @@ def patch_time(dt=None):
         Method with adjusted datetime.
     """
     if dt is not None and not isinstance(dt, datetime.datetime) and callable(dt):
-        raise KeyError("Patch time incorrectly called. Make sure you patched through @patch_time() and not @patch_time")
+        raise ValueError(
+            "Patch time incorrectly called. Make sure you patched through @patch_time() and not @patch_time")
 
     def wrapper_func(func):
         def inner(*args, **kwargs):
             with patch('django.utils.timezone.now') as mock:
                 mock.side_effect = mock_now(dt=dt)
                 func(*args, **kwargs)
+
         return inner
+
     return wrapper_func
 
 

--- a/utils/testing/patch_utils.py
+++ b/utils/testing/patch_utils.py
@@ -8,13 +8,13 @@ __all__ = ["patch", "patch_time", "mock_now"]
 
 
 def patch_time(dt=None):
-    """ Adjusts current time to a set point in time for the patched testcase method.
+    """Adjusts current time to a set point in time for the patched testcase method.
 
     Args:
-        dt: The 'current' datetime according to the program. Defaults to monday 25th of april 2022 10 o'clock
+        dt: The 'current' datetime according to the program. Defaults to Monday 25th of April 2022 10 o'clock.
 
-    Returns: Method with adjusted datetime
-
+    Returns:
+        Method with adjusted datetime.
     """
     if dt is not None and not isinstance(dt, datetime.datetime) and callable(dt):
         raise KeyError("Patch time incorrectly called. Make sure you patched through @patch_time() and not @patch_time")
@@ -43,13 +43,12 @@ class TestPatchMixin:
 
     @staticmethod
     def assert_has_no_call(mock: Mock, **kwargs):
-        """ Assert that a given mock does not have a call with the (partially) given attributes.
+        """Asserts that a given mock does not have a call with the (partially) given attributes.
 
         Args:
             mock: The Mock instance
-            **kwargs: List of keyword arguments used in the method call
-            Use arg_## as a keyword argument to check for a non-keyworded argument in original method call
-
+            kwargs: List of keyword arguments used in the method call.
+                Use arg_## as a keyword argument to check for a non-keyword argument in original method call.
         """
         try:
             TestPatchMixin.assert_has_call(mock, **kwargs)
@@ -60,16 +59,16 @@ class TestPatchMixin:
 
     @staticmethod
     def assert_has_call(mock: Mock, **kwargs):
-        """ Assert that a given mock has a call with the (partially) given attributes.
+        """Asserts that a given mock has a call with the (partially) given attributes.
 
         Args:
-            mock: The Mock instance
-            **kwargs: List of keyword arguments used in the method call
-            Use arg_## as a keyword argument to check for a non-keyworded argument in original method call
+            mock: The Mock instance.
+            kwargs: List of keyword arguments used in the method call.
+                Use arg_## as a keyword argument to check for a non-keyword argument in original method call
 
-        Returns: A list of all valid calls represented as dictionaries. Use 'args' key to retrieve initial method
-         arguments from the dict.
-
+        Returns:
+            A list of all valid calls represented as dictionaries. Use 'args' key to retrieve initial method
+            arguments from the dict.
         """
         # Copy the dict so in the case of an error we can reconstruct the given kwargs
         call_kwargs = kwargs.copy()

--- a/utils/tests/test_form_validation.py
+++ b/utils/tests/test_form_validation.py
@@ -2,13 +2,12 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-
 from utils.testing.form_test_utils import FormValidityMixin
 
 
 class TestFormValidityMixin(FormValidityMixin, TestCase):
     class TestForm(forms.Form):
-        """ Fictive form for Form testing used in TestFormValidityMixin"""
+        """Fictive form for Form testing used in TestFormValidityMixin."""
         main_field = forms.CharField(required=False)
         fake_field = forms.CharField(required=False)
 
@@ -22,10 +21,11 @@ class TestFormValidityMixin(FormValidityMixin, TestCase):
             if self.cleaned_data.get('main_field', '') == "break_form":
                 raise ValidationError('Test form exception', code='invalid_form')
             return self.cleaned_data
+
     form_class = TestForm
     longMessage = False
 
-    def raisesAssertionError(self, method, *args, **kwargs):
+    def raises_assertion_error(self, method, *args, **kwargs):
         if isinstance(method, str):
             method = self.__getattribute__(method)
         try:
@@ -33,13 +33,13 @@ class TestFormValidityMixin(FormValidityMixin, TestCase):
         except AssertionError as error:
             return error
         else:
-            raise AssertionError(f"Assertionerror not raised on {method_name}")
+            raise AssertionError(f"AssertionError not raised on {method.__name__}")
 
-    def test_assertHasField(self):
+    def test_assert_has_field(self):
         # This should not raise an error
-        self.assertHasField('main_field')
+        self.assert_has_field('main_field')
         # This should
-        error = self.raisesAssertionError(self.assertHasField, 'missing_field')
+        error = self.raises_assertion_error(self.assert_has_field, 'missing_field')
         self.assertEqual(
             error.__str__(),
             "{field_name} was not a field in {form_class_name}".format(
@@ -48,11 +48,11 @@ class TestFormValidityMixin(FormValidityMixin, TestCase):
             )
         )
 
-    def test_assertFormValid(self):
+    def test_assert_form_valid(self):
         # This should not raise an error
-        self.assertFormValid({'main_field': "ok"})
+        self.assert_form_valid({'main_field': "ok"})
         # This should
-        error = self.raisesAssertionError(self.assertFormValid, {'main_field': "break_field"})
+        error = self.raises_assertion_error(self.assert_form_valid, {'main_field': "break_field"})
         self.assertEqual(
             error.__str__(),
             "The form was not valid. At least one error was encountered: '{exception_text}' in '{location}'".format(
@@ -61,44 +61,30 @@ class TestFormValidityMixin(FormValidityMixin, TestCase):
             )
         )
 
-    def test_assertFormHasError_in_field(self):
-        self.assertFormHasError({'main_field': 'break_field'}, 'invalid_field')
-        self.assertFormHasError({'main_field': 'break_field'}, 'invalid_field', field='main_field')
+    def test_assert_form_has_error_in_field(self):
+        self.assert_form_has_error({'main_field': 'break_field'}, 'invalid_field')
+        self.assert_form_has_error({'main_field': 'break_field'}, 'invalid_field', field='main_field')
 
         # Error is in main_field not fake_field
-        self.raisesAssertionError(self.assertFormHasError, {'main_field': 'break_field'}, 'invalid_form', field='fake_field')
+        with self.assertRaises(AssertionError):
+            self.assert_form_has_error({'main_field': 'break_field'}, 'invalid_form', field='fake_field')
+
         # This next data raises an error, just not the one with this code
-        error = self.raisesAssertionError(self.assertFormHasError, {'main_field': 'break_field'}, 'invalid_data', field='main_field')
-        self.assertEqual(
-            error.__str__(),
-            "Form did not contain an error with code '{code}' in field '{field}'".format(
-                code='invalid_data',
-                field='main_field',
+        with self.assertRaises(AssertionError):
+            self.assert_form_has_error({'main_field': 'break_field'}, 'invalid_data', field='main_field')
 
-            )
-        )
+    def test_assert_form_has_error_in_form(self):
+        self.assert_form_has_error({'main_field': 'break_form'}, 'invalid_form')
 
-    def test_assertFormHasError_in_form(self):
-        self.assertFormHasError({'main_field': 'break_form'}, 'invalid_form')
-
-        # Should raise no error
-        error = self.raisesAssertionError(self.assertFormHasError, {'main_field': 'break_nothing'}, 'invalid_form')
+        # Should raise AssertionError because the form contains no errors.
+        error = self.raises_assertion_error(self.assert_form_has_error, {'main_field': 'break_nothing'}, 'invalid_form')
         self.assertEqual(error.__str__(), "The form contained no errors")
-        # Error is not in main_field, but elsewhere
-        error = self.raisesAssertionError(self.assertFormHasError, {'main_field': 'break_form'}, 'invalid_form', field='main_field')
-        self.assertEqual(
-            error.__str__(),
-            "Form did not encounter an error in '{field_name}'.".format(
-                field_name='main_field',
-            )
-        )
-        # Error code is not correct, but there is another error
-        error = self.raisesAssertionError(self.assertFormHasError, {'main_field': 'break_form'}, 'invalid_field')
-        self.assertEqual(
-            error.__str__(),
-            "Form did not contain an error with code '{code}'. Though there was another error: '{exception}'".format(
-                code='invalid_field',
-                exception="['Test form exception']"
 
-            )
-        )
+        # Error is not in main_field, but elsewhere
+        error = self.raises_assertion_error(self.assert_form_has_error, {'main_field': 'break_form'}, 'invalid_form',
+                                            field='main_field')
+        self.assertEqual(str(error), "Form did not contain an error with code 'invalid_form', with field=main_field.")
+
+        # Error code is not correct, but there is another error
+        error = self.raises_assertion_error(self.assert_form_has_error, {'main_field': 'break_form'}, 'invalid_field')
+        self.assertEqual(str(error), "Form did not contain an error with code 'invalid_field', with field=None.")


### PR DESCRIPTION
The tests in `utils/tests/test_form_validation.py` did not execute because they were not found by the test discovery. The test discovery only looks in Python ~~modules~~ modules and packages, and because the folder `utils` did not have `__init__.py` it was not a valid ~~module~~package.

Some tests that did not execute before now failed. After fixing, other tests failed that depended on it. These have been fixed as well.

Most changes in this PR are for formatting and the rest are the fixed test cases.