### PR TITLE
Contact info

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,5 @@ django-autocomplete-light
 environs[django]
 whitenoise  # Used for static files in production
 Pillow  # This one can possibly be removed
+
+django-phonenumber-field[phonenumbers]

--- a/scaladining/settings.py
+++ b/scaladining/settings.py
@@ -59,6 +59,8 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.socialaccount',
     'allauthproviders.quadrivium',
+
+    'phonenumber_field',
 ]
 
 MIDDLEWARE = [

--- a/userdetails/models.py
+++ b/userdetails/models.py
@@ -3,12 +3,21 @@ from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
 from django.utils import timezone
 from django.utils.functional import cached_property
+from phonenumber_field.modelfields import PhoneNumberField
 
 from .managers import UserManager, AssociationManager
 
 
 class User(AbstractUser):
     email = models.EmailField("email address", unique=True)
+
+    # PhoneNumberField uses a phone number input widget and prevents abuse of the field for non-phone number data.
+    phone_number = PhoneNumberField(blank=True, help_text="If given, will be visible to other diners on the same list.")
+    email_public = models.BooleanField(
+        'email public',
+        default=False,
+        help_text="If selected, your email address will be visible to other diners on the same list."
+    )
 
     objects = UserManager()
 


### PR DESCRIPTION
Adds fields for contact info (phone number and email) to the user profile settings. The contact info is visible to everyone who subscribed to the same dining list.

Closes #138.

WIP: I have to wait for the other PRs to be merged/rejected.