### PR TITLE
Fix dining list can not be adjusted

### DIFF
--- a/dining/models.py
+++ b/dining/models.py
@@ -82,9 +82,6 @@ class DiningList(models.Model):
     is_adjustable.boolean = True
 
     def clean(self):
-        # Validate dining list can be changed.
-        if self.pk and not self.is_adjustable():
-            raise ValidationError("The dining list is not adjustable", code='closed')
         # Set sign up deadline to a default if it hasn't been set already.
         if not self.sign_up_deadline:
             self.sign_up_deadline = datetime.combine(
@@ -120,11 +117,14 @@ class DiningList(models.Model):
 
     def clean_fields(self, exclude=None):
         super().clean_fields(exclude=exclude)
-        # Valid sign up deadline
+        # Validate sign up deadline.
+        #
+        # We can't put this in clean(), because then forms which put this field in the exclude list break.
         if not exclude or 'sign_up_deadline' not in exclude:
             if self.sign_up_deadline and self.sign_up_deadline.date() > self.date:
                 raise ValidationError(
-                    {'sign_up_deadline': ["Sign up deadline can't be later than the day dinner is served"]})
+                    {'sign_up_deadline': ["Sign up deadline can't be later than the day dinner is served."]}
+                )
 
 
 class DiningEntryManager(models.Manager):

--- a/dining/tests/test_forms.py
+++ b/dining/tests/test_forms.py
@@ -514,16 +514,6 @@ class TestDiningInfoForm(FormValidityMixin, TestCase):
         self.assertEqual(updated_dining_list.max_diners, 14)
         self.assertNotEqual(updated_dining_list.sign_up_deadline.time(), self.dining_list.sign_up_deadline)
 
-    def test_form_editing_time_limit(self):
-        """Asserts that the form can not be used after the timelimit."""
-        # Set the dining list to an old date and assert that we have a 'closed' error.
-        self.dining_list.date = date(2000, 1, 1)
-        form = DiningInfoForm({'dish': 'Test'}, instance=self.dining_list)
-        self.assertTrue(form.has_error(NON_FIELD_ERRORS, code='closed'))
-
-        # Note: this tests the DiningList.clean() method and thus should be there instead of
-        # on DiningInfoForm.
-
     def test_kitchen_open_time_validity(self):
         """Asserts that the meal can't be served before the kitchen opening time."""
         dt = datetime.combine(date(2000, 1, 1), settings.KITCHEN_USE_START_TIME) - timedelta(minutes=1)


### PR DESCRIPTION
This PR removes the check for `is_adjustable` from the DiningList clean method.

I have checked and it is safe to do so. Each form has their own check on `is_adjustable` when it is applicable. It should be on forms anyway instead of on the model clean method, because some forms should be able to modify the dining list after the adjustable period.